### PR TITLE
Implement traction on ship controls

### DIFF
--- a/Assets/Scenes/Test World.unity
+++ b/Assets/Scenes/Test World.unity
@@ -38670,9 +38670,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   interactTarget: {fileID: 1734052715}
   linearAcceleration: 1
-  linearDeceleration: 0.1
-  angularAcceleration: 1
-  angularDeceleration: 0.1
+  angularAcceleration: 0.25
+  traction: 0.75
   bobSpeed: 1
   bobRange: 0.1
 --- !u!54 &1242931191
@@ -38684,8 +38683,8 @@ Rigidbody:
   m_GameObject: {fileID: 1242931188}
   serializedVersion: 4
   m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 0.1
+  m_AngularDrag: 0.5
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
   m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}

--- a/Assets/Scripts/Flying Vehicle.cs
+++ b/Assets/Scripts/Flying Vehicle.cs
@@ -5,9 +5,8 @@ public class FlyingVehicle : MonoBehaviour
 {
     [SerializeField] private Interactable interactTarget;
     [SerializeField] private float linearAcceleration = 1.0f;
-    [SerializeField] private float linearDeceleration = 0.1f;
-    [SerializeField] private float angularAcceleration = 1.0f;
-    [SerializeField] private float angularDeceleration = 0.1f;
+    [SerializeField] private float angularAcceleration = 0.25f;
+    [SerializeField] private float traction = 0.75f;
     [SerializeField] private float bobSpeed = 1.0f;
     [SerializeField] private float bobRange = 0.1f;
     private Camera playerCamera = null;
@@ -48,6 +47,11 @@ public class FlyingVehicle : MonoBehaviour
         rbody.AddTorque(transform.up*impetus.x*angularAcceleration*Time.deltaTime, ForceMode.Impulse);
         rbody.AddForce(transform.forward*impetus.z*linearAcceleration*Time.deltaTime, ForceMode.Impulse);
         rbody.AddForce(Vector3.up*bobSpeed*bobDirection*Time.deltaTime, ForceMode.Impulse);
+        rbody.linearVelocity = Vector3.Lerp(
+            rbody.linearVelocity,
+            Vector3.ProjectOnPlane(rbody.linearVelocity, transform.right),
+            traction
+        );
     }
 
     void TryAcquireFocus(GameObject player) {

--- a/Assets/Scripts/Flying Vehicle.cs
+++ b/Assets/Scripts/Flying Vehicle.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 [RequireComponent(typeof(Rigidbody))]
@@ -50,7 +51,7 @@ public class FlyingVehicle : MonoBehaviour
         rbody.linearVelocity = Vector3.Lerp(
             rbody.linearVelocity,
             Vector3.ProjectOnPlane(rbody.linearVelocity, transform.right),
-            traction
+            1.0f - Mathf.Pow(1.0f - traction, Time.deltaTime*60.0f)
         );
     }
 


### PR DESCRIPTION
Closes #26 . The implementation works by continuously lerping `linearVelocity` between the value it already holds and the result of projecting that value onto the ship's YZ plane.