### PR TITLE
Implement LevelBounds and Checkpoint

### DIFF
--- a/Assets/Scripts/Controllers/InputModeManager.cs
+++ b/Assets/Scripts/Controllers/InputModeManager.cs
@@ -41,12 +41,15 @@ public class InputModeManager : MonoBehaviour
 
     private void OnEnable()
     {
-        inputActions.Disable();
         SwitchToPlayerControls();
-        inputMode = InputMode.Player;
     }
 
     private void OnDisable()
+    {
+        DisableAllControls();
+    }
+
+    public void DisableAllControls()
     {
         inputActions.Disable();
         inputMode = InputMode.None;
@@ -54,24 +57,21 @@ public class InputModeManager : MonoBehaviour
 
     public void SwitchToPlayerControls()
     {
+        inputActions.Disable();
         inputActions.Player.Enable();   // Enable Player action map
-        inputActions.Flying.Disable();  // Disable Flying action map
-        inputActions.UI.Disable();
         inputMode = InputMode.Player;
     }
 
     public void SwitchToShipControls()
     {
-        inputActions.Player.Disable();  // Disable Player action map
+        inputActions.Disable();
         inputActions.Flying.Enable();   // Enable Flying action map
-        inputActions.UI.Disable();
         inputMode = InputMode.Flying;
     }
 
     public void SwitchToUIControls()
     {
-        inputActions.Player.Disable();
-        inputActions.Flying.Disable();
+        inputActions.Disable();
         inputActions.UI.Enable();
         inputMode = InputMode.UI;
     }

--- a/Assets/Scripts/Level/Checkpoint.cs
+++ b/Assets/Scripts/Level/Checkpoint.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+using System;
+using System.Collections;
+
+public class Checkpoint : MonoBehaviour
+{
+    [SerializeField] private bool useAsDefaultCheckpoint;
+
+    public static event Action<Checkpoint> OnSet;
+    public static event Action<Checkpoint> OnRespawn;
+
+    private static Checkpoint current = null;
+
+    public void Start()
+    {
+        /* If any checkpoint is marked default,
+         * the last one marked default will be used by default. */
+        if (useAsDefaultCheckpoint)
+        {
+            Set(this);
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.GetComponent<PlayerCharacterController>())
+        {
+            Set(this);
+        }
+    }
+
+    public static void Set(Checkpoint which)
+    {
+        current = which;
+        OnSet?.Invoke(current);
+    }
+
+    public static void Respawn(Checkpoint which = null)
+    {
+        (which ? which : current)?.StartCoroutine("RespawnCoro");
+    }
+
+    private IEnumerator RespawnCoro()
+    {
+        InputModeManager.Instance.DisableAllControls();
+        SceneCore.playerCharacter.enabled = false;
+        SceneCore.playerCharacter.transform.position = transform.position;
+        OnRespawn?.Invoke(this);
+        yield return new WaitForSeconds(0.02f);
+        SceneCore.playerCharacter.enabled = true;
+        InputModeManager.Instance.SwitchToPlayerControls();
+    }
+}

--- a/Assets/Scripts/Level/Checkpoint.cs.meta
+++ b/Assets/Scripts/Level/Checkpoint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f170bf43fd59b75cda3635fbe2b3a1d5

--- a/Assets/Scripts/Level/LevelBounds.cs
+++ b/Assets/Scripts/Level/LevelBounds.cs
@@ -2,20 +2,11 @@ using UnityEngine;
 
 public class LevelBounds : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
     void OnTriggerExit(Collider playerCollider)
     {
-        //respawn here
+        if (playerCollider.GetComponent<PlayerCharacterController>())
+        {
+            Checkpoint.Respawn();
+        }
     }
 }


### PR DESCRIPTION
Closes #188 

Next steps needed:

- Implement a smoother transition in `Checkpoint.RespawnCoro` if a smooth transition is desired (would require e.g. adding fade overlay objects to the canvas)
- Add `Checkpoint` component to the player spawn points and mark the player's initial spawn point as default checkpoint
- When interacting with `NightmareShip`, set current checkpoint to jail spawn point with `Checkpoint.Set(Checkpoint where)`
- Somewhere, e.g. maybe on `NightmareShip` or on the jail spawn point, listen for event `Checkpoint.OnRespawn(Checkpoint where)`, and if the destination `where` equals the jail spawn point, stop the camera animation started by interacting with `NightmareShip`
- Optional: add a checkpoint to the (real) ship