### PR TITLE
Fix external package readme file that for some reason was preventing …

### DIFF
--- a/Assets/IgniteCoders/Simple Water Shader/Info/Readme.asset
+++ b/Assets/IgniteCoders/Simple Water Shader/Info/Readme.asset
@@ -17,18 +17,18 @@ MonoBehaviour:
   sections:
   - heading: Simple Water Shader
     text: 'This asset simulates a simple water using the Universal Render Pipeline (URP) and Shader Graph.'
-    linkText: 
-    url: 
+    linkText:
+    url:
   - heading:
     text: 'You can change colors, transparency, displacement... etc.'
-    linkText: 
-    url: 
+    linkText:
+    url:
   - heading:
-    text: 'There's a ReflectionCamera prefab with a script for mirroring the main camera, bus doesn't looks good in all situations.'
-    linkText: 
-    url: 
+    text: 'There is a ReflectionCamera prefab with a script for mirroring the main camera, bus does not looks good in all situations.'
+    linkText:
+    url:
   - heading:
     text: 'The Shader is well organized for better manipulation and configuration.'
-    linkText: 
-    url: 
+    linkText:
+    url:
   loadedLayout: 1


### PR DESCRIPTION
…the scene editor from working

Fixes #384 

The readme file was using apostrophes for contractions in a string that was using apostrophes as delimiters, thus causing some parts of the string to be unquoted and interpreted as syntax. Why this was preventing the scene editor from working, I have no idea, but the way I found it was this thread on the official Unity forum:

https://discussions.unity.com/t/cant-move-scene-view-with-wasd-or-arrows-anymore/91028/14