### PR TITLE
Fine-tune API and behavior of destructible meshes.

### DIFF
--- a/Assets/Prefabs/Core/Ship.prefab
+++ b/Assets/Prefabs/Core/Ship.prefab
@@ -568,12 +568,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 1
+  maxHealth: 100
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6572537941750540480
@@ -972,12 +974,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!4 &9164201418045398679 stripped
@@ -1079,12 +1083,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 1220810248042170844}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1001 &2068576807380155703
@@ -1290,12 +1296,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!4 &4055760061330304087 stripped
@@ -1574,12 +1582,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1001 &3950339374701435740
@@ -1680,12 +1690,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1001 &4435823176448448917
@@ -1782,12 +1794,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 1220810248042170844}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1001 &4813330078298809311
@@ -1879,12 +1893,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 1220810248042170844}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!4 &3051682033147672594 stripped
@@ -2110,12 +2126,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!4 &2154978175016270491 stripped
@@ -9929,12 +9947,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &24784859635300843 stripped
@@ -9976,12 +9996,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &32505754592160172 stripped
@@ -10023,12 +10045,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &41486627371298124 stripped
@@ -10070,12 +10094,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &52193637737610335 stripped
@@ -10117,12 +10143,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &58386138655635845 stripped
@@ -10164,12 +10192,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &60888878121129752 stripped
@@ -10211,12 +10241,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &65557158562280347 stripped
@@ -10258,12 +10290,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &65655737677523477 stripped
@@ -10305,12 +10339,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &72880086939330000 stripped
@@ -10352,12 +10388,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &107569358882989434 stripped
@@ -10399,12 +10437,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &108607359367220183 stripped
@@ -10446,12 +10486,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &124003647183359636 stripped
@@ -10493,12 +10535,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &165932113221018401 stripped
@@ -10540,12 +10584,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &169397942769577446 stripped
@@ -10587,12 +10633,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &171300152578644947 stripped
@@ -10634,12 +10682,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &185415275587550268 stripped
@@ -10681,12 +10731,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &186320974693983323 stripped
@@ -10728,12 +10780,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &187603502047771661 stripped
@@ -10775,12 +10829,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &229540467116190096 stripped
@@ -10822,12 +10878,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &274050180908515091 stripped
@@ -10869,12 +10927,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &285438907500222788 stripped
@@ -10916,12 +10976,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &291947114666506332 stripped
@@ -10963,12 +11025,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &313275953839596735 stripped
@@ -11010,12 +11074,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &321712070043339333 stripped
@@ -11057,12 +11123,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &345819605727998848 stripped
@@ -11104,12 +11172,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &350138403165799928 stripped
@@ -11151,12 +11221,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &356421645999455675 stripped
@@ -11198,12 +11270,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &389745231392625909 stripped
@@ -11245,12 +11319,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &398655788562752330 stripped
@@ -11292,12 +11368,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &411747829206190419 stripped
@@ -11339,12 +11417,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &412571848753209721 stripped
@@ -11386,12 +11466,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &415528585884542118 stripped
@@ -11433,12 +11515,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &469170205533436714 stripped
@@ -11480,12 +11564,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &504901054483011007 stripped
@@ -11527,12 +11613,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &520314319844030907 stripped
@@ -11574,12 +11662,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &529844280988817958 stripped
@@ -11621,12 +11711,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &537529326072080631 stripped
@@ -11668,12 +11760,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &540589146799663693 stripped
@@ -11715,12 +11809,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &544848309130645288 stripped
@@ -11762,12 +11858,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &592537023129625051 stripped
@@ -11809,12 +11907,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &600570598624233860 stripped
@@ -11856,12 +11956,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &608027248182591291 stripped
@@ -11903,12 +12005,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &613456589697856349 stripped
@@ -11950,12 +12054,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &628746317467254601 stripped
@@ -11997,12 +12103,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &634359085729485975 stripped
@@ -12044,12 +12152,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &667922614434528103 stripped
@@ -12091,12 +12201,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &668525127258820334 stripped
@@ -12138,12 +12250,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &709036662323409910 stripped
@@ -12185,12 +12299,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &709681171779980274 stripped
@@ -12232,12 +12348,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &725393533991460531 stripped
@@ -12279,12 +12397,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &729050454589847604 stripped
@@ -12326,12 +12446,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &732404758127563912 stripped
@@ -12373,12 +12495,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &741933746675016245 stripped
@@ -12420,12 +12544,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &750907415474741109 stripped
@@ -12467,12 +12593,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &772720812943265440 stripped
@@ -12514,12 +12642,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &790469116693663759 stripped
@@ -12561,12 +12691,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &797647341754402588 stripped
@@ -12608,12 +12740,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &797830411755380293 stripped
@@ -12655,12 +12789,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &799870569185071353 stripped
@@ -12702,12 +12838,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &808423254044001239 stripped
@@ -12749,12 +12887,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &809936734054009068 stripped
@@ -12796,12 +12936,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &820433814665626095 stripped
@@ -12843,12 +12985,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &823558254156249152 stripped
@@ -12890,12 +13034,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &844978264194299110 stripped
@@ -12937,12 +13083,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &852542402101220437 stripped
@@ -12984,12 +13132,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &870325136574445316 stripped
@@ -13031,12 +13181,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &877407915389144918 stripped
@@ -13078,12 +13230,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &880666682683398589 stripped
@@ -13125,12 +13279,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &881067055785324587 stripped
@@ -13172,12 +13328,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &885259741564741254 stripped
@@ -13219,12 +13377,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &890560561343132136 stripped
@@ -13266,12 +13426,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &898362946914672026 stripped
@@ -13313,12 +13475,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &903448438270494627 stripped
@@ -13360,12 +13524,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &914327783184081047 stripped
@@ -13407,12 +13573,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &941187797331420874 stripped
@@ -13454,12 +13622,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &991660079253991441 stripped
@@ -13501,12 +13671,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &994158015944624614 stripped
@@ -13548,12 +13720,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1056058553164819054 stripped
@@ -13595,12 +13769,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1060729751598406777 stripped
@@ -13642,12 +13818,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1066891932111738968 stripped
@@ -13689,12 +13867,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1095727742029252351 stripped
@@ -13736,12 +13916,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1114733411732265189 stripped
@@ -13783,12 +13965,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1130725066581637497 stripped
@@ -13830,12 +14014,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1150099885328058346 stripped
@@ -13877,12 +14063,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1160864136493810177 stripped
@@ -13924,12 +14112,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1165136076301163262 stripped
@@ -13971,12 +14161,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1184366916580598949 stripped
@@ -14018,12 +14210,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1196262760862217539 stripped
@@ -14065,12 +14259,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1203940137537710826 stripped
@@ -14112,12 +14308,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1226860805374244109 stripped
@@ -14159,12 +14357,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1253465142393864116 stripped
@@ -14206,12 +14406,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1266436020417707100 stripped
@@ -14253,12 +14455,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1288738880183220034 stripped
@@ -14300,12 +14504,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1303315887112960859 stripped
@@ -14347,12 +14553,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1323304748130384693 stripped
@@ -14394,12 +14602,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1326841399795714376 stripped
@@ -14441,12 +14651,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1339367963930219974 stripped
@@ -14488,12 +14700,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1348514765438592560 stripped
@@ -14535,12 +14749,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1352954283994027964 stripped
@@ -14582,12 +14798,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1354022859487176390 stripped
@@ -14629,12 +14847,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1360438332116367140 stripped
@@ -14676,12 +14896,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1375089984553617832 stripped
@@ -14723,12 +14945,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1399391754670716075 stripped
@@ -14770,12 +14994,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1408126911722722310 stripped
@@ -14817,12 +15043,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1420746508310375031 stripped
@@ -14864,12 +15092,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1423281615682565455 stripped
@@ -14911,12 +15141,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1430488173754346127 stripped
@@ -14958,12 +15190,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1442722714065867539 stripped
@@ -15005,12 +15239,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1450588155041924238 stripped
@@ -15052,12 +15288,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1451435963639177261 stripped
@@ -15099,12 +15337,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1484954946781756976 stripped
@@ -15146,12 +15386,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1485736137368891567 stripped
@@ -15193,12 +15435,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1499665914480660059 stripped
@@ -15240,12 +15484,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1500659275128377493 stripped
@@ -15287,12 +15533,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1513453030912547896 stripped
@@ -15334,12 +15582,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1525443399490027487 stripped
@@ -15381,12 +15631,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1555355301742205415 stripped
@@ -15428,12 +15680,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1578937449057114330 stripped
@@ -15475,12 +15729,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1587156160196270392 stripped
@@ -15522,12 +15778,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1589844095506520602 stripped
@@ -15569,12 +15827,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1597515738499068955 stripped
@@ -15616,12 +15876,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1612198509748195044 stripped
@@ -15663,12 +15925,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1614263288843226585 stripped
@@ -15710,12 +15974,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1638373833217192201 stripped
@@ -15757,12 +16023,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1639993053867071298 stripped
@@ -15804,12 +16072,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1673912411458684213 stripped
@@ -15851,12 +16121,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1687384992803781977 stripped
@@ -15898,12 +16170,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1724004031573575787 stripped
@@ -15945,12 +16219,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1732475699495511563 stripped
@@ -15992,12 +16268,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1738836591398443961 stripped
@@ -16039,12 +16317,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1740298442139117951 stripped
@@ -16086,12 +16366,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1751604139824854701 stripped
@@ -16133,12 +16415,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1784608535665996353 stripped
@@ -16180,12 +16464,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1793385258436918472 stripped
@@ -16227,12 +16513,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1826386706265257621 stripped
@@ -16274,12 +16562,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1832901316055627948 stripped
@@ -16321,12 +16611,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1844910930905962383 stripped
@@ -16368,12 +16660,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1861253207458651862 stripped
@@ -16415,12 +16709,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1879328537523599448 stripped
@@ -16462,12 +16758,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1890554743980219604 stripped
@@ -16509,12 +16807,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1903986996666896540 stripped
@@ -16556,12 +16856,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1918901122246135181 stripped
@@ -16603,12 +16905,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1925749784948771165 stripped
@@ -16650,12 +16954,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1930870595300566809 stripped
@@ -16697,12 +17003,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1931348040471657416 stripped
@@ -16744,12 +17052,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1938819536820985156 stripped
@@ -16791,12 +17101,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1947284966230862837 stripped
@@ -16838,12 +17150,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1952428801102508230 stripped
@@ -16885,12 +17199,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1954971296661118339 stripped
@@ -16932,12 +17248,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1955123389881996511 stripped
@@ -16979,12 +17297,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1981513709406979729 stripped
@@ -17026,12 +17346,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &1990842910702820173 stripped
@@ -17073,12 +17395,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2006931907481290736 stripped
@@ -17120,12 +17444,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2008569322907412913 stripped
@@ -17167,12 +17493,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2010300098580715788 stripped
@@ -17214,12 +17542,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2044053304240815771 stripped
@@ -17261,12 +17591,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2053704552646071109 stripped
@@ -17308,12 +17640,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2064752820845302264 stripped
@@ -17355,12 +17689,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2067600438751484024 stripped
@@ -17402,12 +17738,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2068535450026330686 stripped
@@ -17449,12 +17787,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2073387680180987682 stripped
@@ -17496,12 +17836,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2087908352721167967 stripped
@@ -17543,12 +17885,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2090510159688612752 stripped
@@ -17590,12 +17934,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2096145048890200992 stripped
@@ -17637,12 +17983,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2099618832404584119 stripped
@@ -17684,12 +18032,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2114301372219594141 stripped
@@ -17731,12 +18081,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2148824535840752529 stripped
@@ -17778,12 +18130,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2149903556546648142 stripped
@@ -17825,12 +18179,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2151971032591486600 stripped
@@ -17872,12 +18228,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2158338282926469070 stripped
@@ -17919,12 +18277,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2168028967028350626 stripped
@@ -17966,12 +18326,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2181764313848295928 stripped
@@ -18013,12 +18375,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2187052675117669991 stripped
@@ -18060,12 +18424,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2194363586168537453 stripped
@@ -18107,12 +18473,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2219314229309741177 stripped
@@ -18154,12 +18522,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2220859353360663881 stripped
@@ -18201,12 +18571,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2225945821280874019 stripped
@@ -18248,12 +18620,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2226656362743207607 stripped
@@ -18295,12 +18669,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2236609160345776954 stripped
@@ -18342,12 +18718,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2249713086252556623 stripped
@@ -18389,12 +18767,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2250092881873289197 stripped
@@ -18436,12 +18816,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2251072324812402860 stripped
@@ -18483,12 +18865,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2257389616791866169 stripped
@@ -18530,12 +18914,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2262924590523729038 stripped
@@ -18577,12 +18963,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2274485099458341735 stripped
@@ -18624,12 +19012,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2281534530215451967 stripped
@@ -18671,12 +19061,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2283217638738366767 stripped
@@ -18718,12 +19110,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2301418296347220772 stripped
@@ -18765,12 +19159,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2306539877832857325 stripped
@@ -18812,12 +19208,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2315315410194802788 stripped
@@ -18859,12 +19257,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2333137476638293519 stripped
@@ -18906,12 +19306,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2336508919727692213 stripped
@@ -18953,12 +19355,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2347647575147965599 stripped
@@ -19000,12 +19404,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2358613625563148767 stripped
@@ -19047,12 +19453,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2359886422103028820 stripped
@@ -19094,12 +19502,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2399233388860657636 stripped
@@ -19141,12 +19551,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2408380463207055751 stripped
@@ -19188,12 +19600,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2416990345540608971 stripped
@@ -19235,12 +19649,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2429520532835294993 stripped
@@ -19282,12 +19698,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2442468561225389371 stripped
@@ -19329,12 +19747,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2446105300093980998 stripped
@@ -19376,12 +19796,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2448184586162914823 stripped
@@ -19423,12 +19845,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2448351072057129396 stripped
@@ -19470,12 +19894,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2449199783674625816 stripped
@@ -19517,12 +19943,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2481116807395250228 stripped
@@ -19564,12 +19992,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2487291739375874717 stripped
@@ -19611,12 +20041,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2507456650743958119 stripped
@@ -19658,12 +20090,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2523637822657875567 stripped
@@ -19705,12 +20139,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2543496343144024484 stripped
@@ -19752,12 +20188,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2578041582805315254 stripped
@@ -19799,12 +20237,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2584034674693590614 stripped
@@ -19846,12 +20286,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2589700579197013686 stripped
@@ -19893,12 +20335,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2621234599928352173 stripped
@@ -19940,12 +20384,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2633677664363153194 stripped
@@ -19987,12 +20433,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2634294934513443210 stripped
@@ -20034,12 +20482,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2635205439708102134 stripped
@@ -20081,12 +20531,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2645490508239549326 stripped
@@ -20128,12 +20580,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2645941887429407983 stripped
@@ -20175,12 +20629,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2674584226440257859 stripped
@@ -20222,12 +20678,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2690242400174212011 stripped
@@ -20269,12 +20727,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2691865411358559003 stripped
@@ -20316,12 +20776,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2704845516971991195 stripped
@@ -20363,12 +20825,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2705121189545596432 stripped
@@ -20410,12 +20874,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2709431487306924643 stripped
@@ -20457,12 +20923,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2722559146706936860 stripped
@@ -20504,12 +20972,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2740073927821027373 stripped
@@ -20551,12 +21021,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2751602049138084913 stripped
@@ -20598,12 +21070,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2756099187711032795 stripped
@@ -20645,12 +21119,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2758742377368303698 stripped
@@ -20692,12 +21168,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2779529616361060989 stripped
@@ -20739,12 +21217,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2800737652485210861 stripped
@@ -20786,12 +21266,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2800815576566890739 stripped
@@ -20833,12 +21315,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2816687910717665204 stripped
@@ -20880,12 +21364,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2832871719730752914 stripped
@@ -20927,12 +21413,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2846762547931058963 stripped
@@ -20974,12 +21462,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2859495324924830312 stripped
@@ -21021,12 +21511,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2889376445847424902 stripped
@@ -21068,12 +21560,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2930269887891704540 stripped
@@ -21115,12 +21609,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2946998125440858213 stripped
@@ -21162,12 +21658,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2951006689610197784 stripped
@@ -21209,12 +21707,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &2986101065544041746 stripped
@@ -21256,12 +21756,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3000245307302764269 stripped
@@ -21303,12 +21805,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3018067160239016587 stripped
@@ -21350,12 +21854,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3027038369132771617 stripped
@@ -21397,12 +21903,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3039695696737831186 stripped
@@ -21444,12 +21952,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3047371104332250850 stripped
@@ -21491,12 +22001,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3049106090275720152 stripped
@@ -21538,12 +22050,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3080605289265493051 stripped
@@ -21585,12 +22099,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3089281968233390637 stripped
@@ -21632,12 +22148,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3093011892652297406 stripped
@@ -21679,12 +22197,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3106538091753545927 stripped
@@ -21726,12 +22246,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3110773695551057968 stripped
@@ -21773,12 +22295,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3127891636594387213 stripped
@@ -21820,12 +22344,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3224196525558608233 stripped
@@ -21867,12 +22393,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3255842792392592376 stripped
@@ -21914,12 +22442,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3257269544391313452 stripped
@@ -21961,12 +22491,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3291501641321289782 stripped
@@ -22008,12 +22540,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3305336998521067256 stripped
@@ -22055,12 +22589,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3317053359223890331 stripped
@@ -22102,12 +22638,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3319732065319295014 stripped
@@ -22149,12 +22687,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3321337578452548273 stripped
@@ -22196,12 +22736,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3321596296418060606 stripped
@@ -22243,12 +22785,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3331856169578200463 stripped
@@ -22290,12 +22834,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3363566416978384224 stripped
@@ -22337,12 +22883,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3400331888176324231 stripped
@@ -22384,12 +22932,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3407742948939534626 stripped
@@ -22431,12 +22981,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3408835359160752257 stripped
@@ -22478,12 +23030,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3426222588445459020 stripped
@@ -22525,12 +23079,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3440597398742560136 stripped
@@ -22572,12 +23128,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3481224245756914293 stripped
@@ -22619,12 +23177,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3483636628579092127 stripped
@@ -22666,12 +23226,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3489274664780987647 stripped
@@ -22713,12 +23275,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3493608964483301244 stripped
@@ -22760,12 +23324,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3501737935514989963 stripped
@@ -22807,12 +23373,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3513628189448723963 stripped
@@ -22854,12 +23422,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3546089058663278896 stripped
@@ -22901,12 +23471,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3553183335563143814 stripped
@@ -22948,12 +23520,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3565364383702847251 stripped
@@ -22995,12 +23569,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3572603469397466232 stripped
@@ -23042,12 +23618,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3573989968932331650 stripped
@@ -23089,12 +23667,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3582033323172476975 stripped
@@ -23136,12 +23716,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3585506923523842060 stripped
@@ -23183,12 +23765,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3599502658347553134 stripped
@@ -23230,12 +23814,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3599621305789856875 stripped
@@ -23277,12 +23863,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3604755225242943952 stripped
@@ -23324,12 +23912,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3607700952120070730 stripped
@@ -23371,12 +23961,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3615652514462493302 stripped
@@ -23418,12 +24010,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3628639527672299288 stripped
@@ -23465,12 +24059,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3659378486876996828 stripped
@@ -23512,12 +24108,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3672651858849590391 stripped
@@ -23559,12 +24157,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3680225135789252534 stripped
@@ -23606,12 +24206,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3711941294962575297 stripped
@@ -23653,12 +24255,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3727084113401793191 stripped
@@ -23700,12 +24304,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3735331093858177452 stripped
@@ -23747,12 +24353,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3736012299480041695 stripped
@@ -23794,12 +24402,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3755825258337427125 stripped
@@ -23841,12 +24451,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3765192249365733424 stripped
@@ -23888,12 +24500,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3765605310033099288 stripped
@@ -23935,12 +24549,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3765948964400654465 stripped
@@ -23982,12 +24598,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3767947108111749378 stripped
@@ -24029,12 +24647,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3790476835317301372 stripped
@@ -24076,12 +24696,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3796093158871926233 stripped
@@ -24123,12 +24745,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3818518714324417795 stripped
@@ -24170,12 +24794,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3826858135677509215 stripped
@@ -24217,12 +24843,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3846892593885472781 stripped
@@ -24264,12 +24892,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3860672663128498707 stripped
@@ -24311,12 +24941,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3866272904533661594 stripped
@@ -24358,12 +24990,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3880927595233038560 stripped
@@ -24405,12 +25039,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3889129974218009526 stripped
@@ -24452,12 +25088,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3948617393254889259 stripped
@@ -24499,12 +25137,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3958967296463689377 stripped
@@ -24546,12 +25186,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3970914236371038159 stripped
@@ -24593,12 +25235,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3975441290614044181 stripped
@@ -24640,12 +25284,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3978902901906742278 stripped
@@ -24687,12 +25333,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &3993287567558847028 stripped
@@ -24734,12 +25382,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4008027851984646194 stripped
@@ -24781,12 +25431,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4022976750717898970 stripped
@@ -24828,12 +25480,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4040377809676914400 stripped
@@ -24875,12 +25529,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4055606376321473853 stripped
@@ -24922,12 +25578,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4059093154588801256 stripped
@@ -24969,12 +25627,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4061137022946645905 stripped
@@ -25016,12 +25676,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4083777764361945158 stripped
@@ -25063,12 +25725,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4096627548962107755 stripped
@@ -25110,12 +25774,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4101309272772103205 stripped
@@ -25157,12 +25823,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4115957278279633674 stripped
@@ -25204,12 +25872,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4123997838287495017 stripped
@@ -25251,12 +25921,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4146662613483705316 stripped
@@ -25298,12 +25970,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4147433842934843817 stripped
@@ -25345,12 +26019,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4154422135965788178 stripped
@@ -25392,12 +26068,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4159528448695485530 stripped
@@ -25439,12 +26117,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4163430961238405026 stripped
@@ -25486,12 +26166,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4168533266546645327 stripped
@@ -25533,12 +26215,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4182267141713127826 stripped
@@ -25580,12 +26264,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4198496989883938344 stripped
@@ -25627,12 +26313,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4199232127813946900 stripped
@@ -25674,12 +26362,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4199259141474642473 stripped
@@ -25721,12 +26411,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4202496427345922792 stripped
@@ -25768,12 +26460,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4211352173207315235 stripped
@@ -25815,12 +26509,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4216994791042432986 stripped
@@ -25862,12 +26558,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4257343048809332271 stripped
@@ -25909,12 +26607,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4281268986547539433 stripped
@@ -25956,12 +26656,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4324515737990028742 stripped
@@ -26003,12 +26705,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4337067864696187629 stripped
@@ -26050,12 +26754,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4342788529866020372 stripped
@@ -26097,12 +26803,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4343742303156643519 stripped
@@ -26144,12 +26852,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4356642585658306706 stripped
@@ -26191,12 +26901,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4372310422950356128 stripped
@@ -26238,12 +26950,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4380588193894658482 stripped
@@ -26285,12 +26999,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4390358325501959889 stripped
@@ -26332,12 +27048,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4396248840271100824 stripped
@@ -26379,12 +27097,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4404455181102100028 stripped
@@ -26426,12 +27146,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4459431719783244652 stripped
@@ -26473,12 +27195,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4466213671383963556 stripped
@@ -26520,12 +27244,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4478870620874850244 stripped
@@ -26567,12 +27293,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4492214962869644942 stripped
@@ -26614,12 +27342,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4510954404224533216 stripped
@@ -26661,12 +27391,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4527588096479467616 stripped
@@ -26708,12 +27440,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4533192848566044142 stripped
@@ -26755,12 +27489,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4539156806213726398 stripped
@@ -26802,12 +27538,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4540860029858953750 stripped
@@ -26849,12 +27587,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4543433133663135911 stripped
@@ -26896,12 +27636,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4551785085215265673 stripped
@@ -26943,12 +27685,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4553809313725751651 stripped
@@ -26990,12 +27734,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4559405524266760655 stripped
@@ -27037,12 +27783,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4562210592732963788 stripped
@@ -27084,12 +27832,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4562559740925850283 stripped
@@ -27131,12 +27881,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4613503317962990002 stripped
@@ -27178,12 +27930,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4616363907773795326 stripped
@@ -27225,12 +27979,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4620895158113087234 stripped
@@ -27272,12 +28028,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4646672612793379284 stripped
@@ -27319,12 +28077,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4656063163991562980 stripped
@@ -27366,12 +28126,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4671196989235885998 stripped
@@ -27413,12 +28175,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4680046789378079178 stripped
@@ -27460,12 +28224,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4688529535799675402 stripped
@@ -27507,12 +28273,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4727755075491109330 stripped
@@ -27554,12 +28322,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4741935818455267421 stripped
@@ -27601,12 +28371,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4769547089210250444 stripped
@@ -27648,12 +28420,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4773029259801979673 stripped
@@ -27695,12 +28469,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4775352725989524828 stripped
@@ -27742,12 +28518,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4800739490961564444 stripped
@@ -27789,12 +28567,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4803357038056680121 stripped
@@ -27836,12 +28616,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4806188354752159562 stripped
@@ -27883,12 +28665,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4810448079321552966 stripped
@@ -27930,12 +28714,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4813041177196537635 stripped
@@ -27977,12 +28763,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4818345363194085131 stripped
@@ -28024,12 +28812,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4827178747989458845 stripped
@@ -28071,12 +28861,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4832010312930569542 stripped
@@ -28118,12 +28910,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4837373603169951522 stripped
@@ -28165,12 +28959,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4838033474142700309 stripped
@@ -28212,12 +29008,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4840196722519328278 stripped
@@ -28259,12 +29057,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4848338429259037943 stripped
@@ -28306,12 +29106,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4853527092805807828 stripped
@@ -28353,12 +29155,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4864488921459602309 stripped
@@ -28400,12 +29204,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4894204334862236190 stripped
@@ -28447,12 +29253,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4895646622412685983 stripped
@@ -28494,12 +29302,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4900106067141616590 stripped
@@ -28541,12 +29351,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4906479812990383261 stripped
@@ -28588,12 +29400,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4916539098399170773 stripped
@@ -28635,12 +29449,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4925811110227518609 stripped
@@ -28682,12 +29498,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4932483366137578563 stripped
@@ -28729,12 +29547,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4934519153973261916 stripped
@@ -28776,12 +29596,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4935174785330480985 stripped
@@ -28823,12 +29645,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4940240372277346919 stripped
@@ -28870,12 +29694,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4941276464660895807 stripped
@@ -28917,12 +29743,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4975780368389889246 stripped
@@ -28964,12 +29792,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &4981311798071548938 stripped
@@ -29011,12 +29841,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5010998886931096044 stripped
@@ -29058,12 +29890,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5044263279138982931 stripped
@@ -29105,12 +29939,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5070509822867787503 stripped
@@ -29152,12 +29988,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5073892886400302820 stripped
@@ -29199,12 +30037,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5082005414404676850 stripped
@@ -29246,12 +30086,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5090998059828678977 stripped
@@ -29293,12 +30135,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5094951044262424561 stripped
@@ -29340,12 +30184,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5100298295078782250 stripped
@@ -29387,12 +30233,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5117528852401038716 stripped
@@ -29434,12 +30282,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5124585451536977943 stripped
@@ -29481,12 +30331,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5150049483030715553 stripped
@@ -29528,12 +30380,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5156633516976476811 stripped
@@ -29575,12 +30429,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5156668250179896674 stripped
@@ -29622,12 +30478,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5175781001025283529 stripped
@@ -29669,12 +30527,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5178339784758827875 stripped
@@ -29716,12 +30576,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5181700179261640584 stripped
@@ -29763,12 +30625,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5199868557473602490 stripped
@@ -29810,12 +30674,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5211912016543781913 stripped
@@ -29857,12 +30723,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5219301981627195554 stripped
@@ -29904,12 +30772,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5262302525198044919 stripped
@@ -29951,12 +30821,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5262753122943457502 stripped
@@ -29998,12 +30870,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5266168457277427526 stripped
@@ -30045,12 +30919,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5269695819351400198 stripped
@@ -30092,12 +30968,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5301333005662828931 stripped
@@ -30139,12 +31017,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5312945259542798790 stripped
@@ -30186,12 +31066,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5315130718832337808 stripped
@@ -30233,12 +31115,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5323909707561547604 stripped
@@ -30280,12 +31164,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5331180095639261764 stripped
@@ -30327,12 +31213,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5342870572842046728 stripped
@@ -30374,12 +31262,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5350515054987044011 stripped
@@ -30421,12 +31311,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5368716384865249404 stripped
@@ -30468,12 +31360,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5370953457411399434 stripped
@@ -30515,12 +31409,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5373612408100047099 stripped
@@ -30562,12 +31458,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5382623830790049886 stripped
@@ -30609,12 +31507,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5405695250704649206 stripped
@@ -30656,12 +31556,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5409940870631592596 stripped
@@ -30703,12 +31605,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5415238636106746654 stripped
@@ -30750,12 +31654,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5420478160443276578 stripped
@@ -30797,12 +31703,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5426235143102746798 stripped
@@ -30844,12 +31752,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5443929047023135312 stripped
@@ -30891,12 +31801,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5463696519682732824 stripped
@@ -30938,12 +31850,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5467519381062072199 stripped
@@ -30985,12 +31899,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5472599669178589554 stripped
@@ -31032,12 +31948,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5477091543151847050 stripped
@@ -31079,12 +31997,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5507717688867263827 stripped
@@ -31126,12 +32046,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5525966125964140267 stripped
@@ -31173,12 +32095,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5542528018264686263 stripped
@@ -31220,12 +32144,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5548466847862422498 stripped
@@ -31267,12 +32193,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5560261011731160082 stripped
@@ -31314,12 +32242,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5566182251208773946 stripped
@@ -31361,12 +32291,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5608978216957131166 stripped
@@ -31408,12 +32340,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5621708471253399491 stripped
@@ -31455,12 +32389,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5628671498844801002 stripped
@@ -31502,12 +32438,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5643562428652411482 stripped
@@ -31549,12 +32487,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5663728544053563026 stripped
@@ -31596,12 +32536,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5667193385582743825 stripped
@@ -31643,12 +32585,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5678816895327786451 stripped
@@ -31690,12 +32634,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5692011415782284269 stripped
@@ -31737,12 +32683,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5693890904917764430 stripped
@@ -31784,12 +32732,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5705205889607387711 stripped
@@ -31831,12 +32781,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5708888023858162908 stripped
@@ -31878,12 +32830,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5711364224452492800 stripped
@@ -31925,12 +32879,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5718648341193469560 stripped
@@ -31972,12 +32928,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5718698854974883009 stripped
@@ -32019,12 +32977,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5722880609607946726 stripped
@@ -32066,12 +33026,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5724434276784360532 stripped
@@ -32113,12 +33075,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5729978692628882210 stripped
@@ -32160,12 +33124,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5735208114849835275 stripped
@@ -32207,12 +33173,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5736211533556185686 stripped
@@ -32254,12 +33222,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5741424921669050282 stripped
@@ -32301,12 +33271,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5744542855595948396 stripped
@@ -32348,12 +33320,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5748032413823217477 stripped
@@ -32395,12 +33369,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5766843678654675496 stripped
@@ -32442,12 +33418,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5773918858934282097 stripped
@@ -32489,12 +33467,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5797263744785479888 stripped
@@ -32536,12 +33516,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5812403910780896973 stripped
@@ -32583,12 +33565,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5824069169516750763 stripped
@@ -32630,12 +33614,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5836854207105707000 stripped
@@ -32677,12 +33663,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5837262458414066651 stripped
@@ -32724,12 +33712,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5839407502651496292 stripped
@@ -32771,12 +33761,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5854261811435460436 stripped
@@ -32818,12 +33810,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5856240422278837923 stripped
@@ -32865,12 +33859,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5871772741563128036 stripped
@@ -32912,12 +33908,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5888828559390987279 stripped
@@ -32959,12 +33957,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5896565992568499271 stripped
@@ -33006,12 +34006,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5905708812453363003 stripped
@@ -33053,12 +34055,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5907462736015640074 stripped
@@ -33100,12 +34104,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5910561100344256435 stripped
@@ -33147,12 +34153,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5912766897648572527 stripped
@@ -33194,12 +34202,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5922419148054090617 stripped
@@ -33241,12 +34251,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5922483666497792662 stripped
@@ -33288,12 +34300,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5958077816402202316 stripped
@@ -33335,12 +34349,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &5979784877898109744 stripped
@@ -33382,12 +34398,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6009679700201550214 stripped
@@ -33429,12 +34447,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6013108053921160188 stripped
@@ -33476,12 +34496,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6023864079749707171 stripped
@@ -33523,12 +34545,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6029713689908944341 stripped
@@ -33570,12 +34594,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6043357348913762974 stripped
@@ -33617,12 +34643,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6046843842186231658 stripped
@@ -33664,12 +34692,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6056411420606579307 stripped
@@ -33711,12 +34741,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6067897638818474238 stripped
@@ -33758,12 +34790,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6083605850478214075 stripped
@@ -33805,12 +34839,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6136279260638748266 stripped
@@ -33852,12 +34888,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6146009502466549397 stripped
@@ -33899,12 +34937,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6160761110920705662 stripped
@@ -33946,12 +34986,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6172698429250207746 stripped
@@ -33993,12 +35035,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6183810796872126678 stripped
@@ -34040,12 +35084,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6192969370330978046 stripped
@@ -34087,12 +35133,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6194110184202820851 stripped
@@ -34134,12 +35182,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6211832233473136899 stripped
@@ -34181,12 +35231,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6214677941024950779 stripped
@@ -34228,12 +35280,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6215845951740231343 stripped
@@ -34275,12 +35329,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6238789575936540240 stripped
@@ -34322,12 +35378,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6240661400758114595 stripped
@@ -34369,12 +35427,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6241002320630139187 stripped
@@ -34416,12 +35476,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6241812582406759666 stripped
@@ -34463,12 +35525,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6252228500793884403 stripped
@@ -34510,12 +35574,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6280848754207255376 stripped
@@ -34557,12 +35623,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6312262426090812522 stripped
@@ -34604,12 +35672,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6314016419298682782 stripped
@@ -34651,12 +35721,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6315324943258505129 stripped
@@ -34698,12 +35770,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6325113718635012344 stripped
@@ -34745,12 +35819,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6335853259713446579 stripped
@@ -34792,12 +35868,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6336717916686751378 stripped
@@ -34839,12 +35917,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6338636322623870927 stripped
@@ -34886,12 +35966,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6343527181258246166 stripped
@@ -34933,12 +36015,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6364348501933692281 stripped
@@ -34980,12 +36064,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6370128211913846495 stripped
@@ -35027,12 +36113,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6444329703065145731 stripped
@@ -35074,12 +36162,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6448252071393849939 stripped
@@ -35121,12 +36211,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6448730513114123661 stripped
@@ -35168,12 +36260,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6459094978503629479 stripped
@@ -35215,12 +36309,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6476758672896545466 stripped
@@ -35262,12 +36358,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6507423849683301150 stripped
@@ -35309,12 +36407,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6523228633974777414 stripped
@@ -35356,12 +36456,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6540232712163853739 stripped
@@ -35403,12 +36505,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6555261012006642756 stripped
@@ -35450,12 +36554,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6565913330525920402 stripped
@@ -35497,12 +36603,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6612909757267232320 stripped
@@ -35544,12 +36652,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6614443712140041461 stripped
@@ -35591,12 +36701,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6621277561912531987 stripped
@@ -35638,12 +36750,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6631661097071633262 stripped
@@ -35685,12 +36799,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6633781568690914804 stripped
@@ -35732,12 +36848,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6637581055768917594 stripped
@@ -35779,12 +36897,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6647236754667567331 stripped
@@ -35826,12 +36946,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6648486137326803908 stripped
@@ -35873,12 +36995,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6649254202847190169 stripped
@@ -35920,12 +37044,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6657240134976789587 stripped
@@ -35967,12 +37093,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6683824266861800262 stripped
@@ -36014,12 +37142,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6693247732440940165 stripped
@@ -36061,12 +37191,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6698663000635306158 stripped
@@ -36108,12 +37240,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6726930337502936433 stripped
@@ -36155,12 +37289,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6727626155328426435 stripped
@@ -36202,12 +37338,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6740500477375946136 stripped
@@ -36249,12 +37387,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6756586495877216061 stripped
@@ -36296,12 +37436,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6764218304827450961 stripped
@@ -36343,12 +37485,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6769599320800410519 stripped
@@ -36390,12 +37534,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!4 &6772503661245870689 stripped
@@ -36442,12 +37588,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6785630686390288179 stripped
@@ -36489,12 +37637,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6815471244142485511 stripped
@@ -36536,12 +37686,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6822544076843975355 stripped
@@ -36583,12 +37735,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6828696383321904613 stripped
@@ -36630,12 +37784,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6833828157980291736 stripped
@@ -36677,12 +37833,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6846611286377200495 stripped
@@ -36724,12 +37882,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6858428420746399736 stripped
@@ -36771,12 +37931,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6859677064655336339 stripped
@@ -36818,12 +37980,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6863780028500335676 stripped
@@ -36865,12 +38029,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6871740095567569639 stripped
@@ -36912,12 +38078,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6879336515753025771 stripped
@@ -36959,12 +38127,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6886920260797375240 stripped
@@ -37006,12 +38176,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6897749506271401096 stripped
@@ -37053,12 +38225,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6903498771747753615 stripped
@@ -37100,12 +38274,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6909534517219557673 stripped
@@ -37147,12 +38323,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6919791292222700646 stripped
@@ -37194,12 +38372,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6920586994863255383 stripped
@@ -37241,12 +38421,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6925360994077093550 stripped
@@ -37288,12 +38470,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6954117155642830998 stripped
@@ -37335,12 +38519,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6976493636820185198 stripped
@@ -37382,12 +38568,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6980854042445812818 stripped
@@ -37429,12 +38617,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &6986020313770652703 stripped
@@ -37476,12 +38666,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7004301068895263156 stripped
@@ -37523,12 +38715,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7009325894251147982 stripped
@@ -37570,12 +38764,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7023215282119858942 stripped
@@ -37617,12 +38813,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7057094818334677237 stripped
@@ -37664,12 +38862,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7072108745387325674 stripped
@@ -37711,12 +38911,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7077079538346837696 stripped
@@ -37758,12 +38960,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7079297826789714741 stripped
@@ -37805,12 +39009,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7116800315253879629 stripped
@@ -37852,12 +39058,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7117877980014307813 stripped
@@ -37899,12 +39107,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7121751397866948676 stripped
@@ -37946,12 +39156,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7124307427806079638 stripped
@@ -37993,12 +39205,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7126080649142063367 stripped
@@ -38040,12 +39254,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7141499985921516435 stripped
@@ -38087,12 +39303,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7160836703529643692 stripped
@@ -38134,12 +39352,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7167032614273018832 stripped
@@ -38181,12 +39401,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7174483856066592242 stripped
@@ -38228,12 +39450,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7190613298814264391 stripped
@@ -38275,12 +39499,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7200955291014778769 stripped
@@ -38322,12 +39548,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7209710370253043935 stripped
@@ -38369,12 +39597,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7219963059901226172 stripped
@@ -38416,12 +39646,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7223092940637949460 stripped
@@ -38463,12 +39695,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7233557757833136185 stripped
@@ -38510,12 +39744,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7240484032125633176 stripped
@@ -38557,12 +39793,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7245229994104483030 stripped
@@ -38604,12 +39842,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7254269609688663791 stripped
@@ -38651,12 +39891,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7260556808456783857 stripped
@@ -38698,12 +39940,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7269108317290993514 stripped
@@ -38745,12 +39989,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7289204942047921447 stripped
@@ -38792,12 +40038,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7293544076812611006 stripped
@@ -38839,12 +40087,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7294449987861097223 stripped
@@ -38886,12 +40136,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7299616642863325837 stripped
@@ -38933,12 +40185,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7319107163058881582 stripped
@@ -38980,12 +40234,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7321233306600325083 stripped
@@ -39027,12 +40283,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7322226975968525691 stripped
@@ -39074,12 +40332,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7350952373818506015 stripped
@@ -39121,12 +40381,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7356320722242647369 stripped
@@ -39168,12 +40430,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7365887195555976070 stripped
@@ -39215,12 +40479,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7377310279185074886 stripped
@@ -39262,12 +40528,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7383702065639467228 stripped
@@ -39309,12 +40577,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7401945864096953113 stripped
@@ -39356,12 +40626,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7448894012319953440 stripped
@@ -39403,12 +40675,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7450332129577058066 stripped
@@ -39450,12 +40724,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7465984091997579229 stripped
@@ -39497,12 +40773,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7478214280763397118 stripped
@@ -39544,12 +40822,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7485875439731454401 stripped
@@ -39591,12 +40871,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7490783262671635724 stripped
@@ -39638,12 +40920,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7513434678313448804 stripped
@@ -39685,12 +40969,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7516237507735030858 stripped
@@ -39732,12 +41018,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7533090232669237836 stripped
@@ -39779,12 +41067,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7543298941961469554 stripped
@@ -39826,12 +41116,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7544346332314558828 stripped
@@ -39873,12 +41165,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7547572469899170204 stripped
@@ -39920,12 +41214,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7549702576510075042 stripped
@@ -39967,12 +41263,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7565983419583972238 stripped
@@ -40014,12 +41312,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7590136851413998689 stripped
@@ -40061,12 +41361,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7596223980797872940 stripped
@@ -40108,12 +41410,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7605869276047178704 stripped
@@ -40155,12 +41459,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7609094379855551612 stripped
@@ -40202,12 +41508,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7619438066024426166 stripped
@@ -40249,12 +41557,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7661385854017656496 stripped
@@ -40296,12 +41606,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7661934708334572895 stripped
@@ -40343,12 +41655,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7711474676932370850 stripped
@@ -40390,12 +41704,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7714996489926130518 stripped
@@ -40437,12 +41753,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7716063841235901396 stripped
@@ -40484,12 +41802,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7719714780943517338 stripped
@@ -40531,12 +41851,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7723556047034202313 stripped
@@ -40578,12 +41900,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7725734217945945506 stripped
@@ -40625,12 +41949,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7745414094075994258 stripped
@@ -40672,12 +41998,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7751589146294317344 stripped
@@ -40719,12 +42047,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7768577200507628340 stripped
@@ -40766,12 +42096,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7776824245172650046 stripped
@@ -40813,12 +42145,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7777540183080134183 stripped
@@ -40860,12 +42194,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7783495127443929850 stripped
@@ -40907,12 +42243,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7792024722714233345 stripped
@@ -40954,12 +42292,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7851410559570687392 stripped
@@ -41001,12 +42341,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7855031572573731634 stripped
@@ -41048,12 +42390,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7904963588547744066 stripped
@@ -41095,12 +42439,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7914013713289868262 stripped
@@ -41142,12 +42488,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7945908069519868321 stripped
@@ -41189,12 +42537,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7949930002118146742 stripped
@@ -41236,12 +42586,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7965955720649496893 stripped
@@ -41283,12 +42635,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7971374215755333397 stripped
@@ -41330,12 +42684,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7976407914824270149 stripped
@@ -41377,12 +42733,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7985664284298263287 stripped
@@ -41424,12 +42782,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7987218081395250521 stripped
@@ -41471,12 +42831,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &7999444090464306689 stripped
@@ -41518,12 +42880,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8034213054247743697 stripped
@@ -41565,12 +42929,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8053478043666010338 stripped
@@ -41612,12 +42978,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8065922054587513069 stripped
@@ -41659,12 +43027,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8083696486469568383 stripped
@@ -41706,12 +43076,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8083843723318317676 stripped
@@ -41753,12 +43125,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8086427769332085138 stripped
@@ -41800,12 +43174,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8103976295782146574 stripped
@@ -41847,12 +43223,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8106342580998947629 stripped
@@ -41894,12 +43272,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8108007896438950328 stripped
@@ -41941,12 +43321,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8108072643616021141 stripped
@@ -41988,12 +43370,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8110844385387104362 stripped
@@ -42035,12 +43419,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8147758854108754434 stripped
@@ -42082,12 +43468,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8155510025635084545 stripped
@@ -42129,12 +43517,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8163337008661391754 stripped
@@ -42176,12 +43566,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8168216408763977158 stripped
@@ -42223,12 +43615,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8175497397208740371 stripped
@@ -42270,12 +43664,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8185142132293944103 stripped
@@ -42317,12 +43713,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8188532985264128793 stripped
@@ -42364,12 +43762,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8197816099930683433 stripped
@@ -42411,12 +43811,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8210994971064693780 stripped
@@ -42458,12 +43860,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8216677175386010658 stripped
@@ -42505,12 +43909,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8216806590389317737 stripped
@@ -42552,12 +43958,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8226533719165316455 stripped
@@ -42599,12 +44007,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8232360090185183929 stripped
@@ -42646,12 +44056,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8254124130274155954 stripped
@@ -42693,12 +44105,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8268085079022633240 stripped
@@ -42740,12 +44154,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8271512757831127928 stripped
@@ -42787,12 +44203,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8294836036907682734 stripped
@@ -42834,12 +44252,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8314523736520339462 stripped
@@ -42881,12 +44301,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8316325855112233776 stripped
@@ -42928,12 +44350,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8331709427400652011 stripped
@@ -42975,12 +44399,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8349530224230635325 stripped
@@ -43022,12 +44448,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8352810457478745875 stripped
@@ -43069,12 +44497,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8373795783035701220 stripped
@@ -43116,12 +44546,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8457410176282110161 stripped
@@ -43163,12 +44595,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8479831585029822855 stripped
@@ -43210,12 +44644,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8483893563678631329 stripped
@@ -43257,12 +44693,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8511328751870116758 stripped
@@ -43304,12 +44742,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8514179637476111248 stripped
@@ -43351,12 +44791,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8525167573121904881 stripped
@@ -43398,12 +44840,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8531723959787089436 stripped
@@ -43445,12 +44889,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8542516582935786473 stripped
@@ -43492,12 +44938,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8557334251175255784 stripped
@@ -43539,12 +44987,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8575344394016932135 stripped
@@ -43586,12 +45036,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8583626461647132071 stripped
@@ -43633,12 +45085,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8586219209117833506 stripped
@@ -43680,12 +45134,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8594380581881422959 stripped
@@ -43727,12 +45183,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8598838985940723146 stripped
@@ -43774,12 +45232,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8599075722435969180 stripped
@@ -43821,12 +45281,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8602687160372656189 stripped
@@ -43868,12 +45330,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8615812956095892905 stripped
@@ -43915,12 +45379,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8631829892155428672 stripped
@@ -43962,12 +45428,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8640904086955870985 stripped
@@ -44009,12 +45477,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8647320931401587694 stripped
@@ -44056,12 +45526,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8647681533369439982 stripped
@@ -44103,12 +45575,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8650278863353488115 stripped
@@ -44150,12 +45624,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8668568821186921306 stripped
@@ -44197,12 +45673,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8690569275935008954 stripped
@@ -44244,12 +45722,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8701915751931486980 stripped
@@ -44291,12 +45771,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8704018504972385158 stripped
@@ -44338,12 +45820,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8725673691299319879 stripped
@@ -44385,12 +45869,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8739342095770975135 stripped
@@ -44432,12 +45918,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8743679879142875207 stripped
@@ -44479,12 +45967,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8762791515220956797 stripped
@@ -44526,12 +46016,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8765483140171423926 stripped
@@ -44573,12 +46065,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8778903280556928669 stripped
@@ -44620,12 +46114,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8782808157311023978 stripped
@@ -44667,12 +46163,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8837609510327127368 stripped
@@ -44714,12 +46212,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8838204456126045398 stripped
@@ -44761,12 +46261,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8843303443744973710 stripped
@@ -44808,12 +46310,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8884124345238861492 stripped
@@ -44855,12 +46359,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8890136174121267018 stripped
@@ -44902,12 +46408,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8892812195697603872 stripped
@@ -44949,12 +46457,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8895451752789100744 stripped
@@ -44996,12 +46506,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8908555120047714699 stripped
@@ -45043,12 +46555,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8922230780631741053 stripped
@@ -45090,12 +46604,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8927367581466593044 stripped
@@ -45137,12 +46653,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8927904745220341291 stripped
@@ -45184,12 +46702,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8929168557666881329 stripped
@@ -45231,12 +46751,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8934066056437523432 stripped
@@ -45278,12 +46800,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8960048009391910645 stripped
@@ -45325,12 +46849,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &8964501806720754138 stripped
@@ -45372,12 +46898,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9008876552232572883 stripped
@@ -45419,12 +46947,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9014209578609562386 stripped
@@ -45466,12 +46996,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9018295250096807484 stripped
@@ -45513,12 +47045,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9019095255064053881 stripped
@@ -45560,12 +47094,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9054874240397217899 stripped
@@ -45607,12 +47143,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9058325667809972559 stripped
@@ -45654,12 +47192,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9074386742844406831 stripped
@@ -45701,12 +47241,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9079605152136634836 stripped
@@ -45748,12 +47290,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9098446416138911461 stripped
@@ -45795,12 +47339,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9115494279945645857 stripped
@@ -45842,12 +47388,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9123671289208085604 stripped
@@ -45889,12 +47437,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9130164571657732380 stripped
@@ -45936,12 +47486,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9189188672111031280 stripped
@@ -45983,12 +47535,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9201593984181934066 stripped
@@ -46030,12 +47584,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9212190557846658747 stripped
@@ -46077,12 +47633,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1 &9212393896102203425 stripped
@@ -46124,12 +47682,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 30
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1001 &6534852992424918270
@@ -46353,12 +47913,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 0}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!4 &5625649227739442013 stripped
@@ -46639,12 +48201,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 1220810248042170844}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!1001 &7713020352687074141
@@ -46747,12 +48311,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f17003c46d853e7aadd18c4fbbe006, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ownerDestructibleMesh: {fileID: 4418638503769594105}
+  _ownerDestructibleMesh: {fileID: 4418638503769594105}
   effectOnHit: {fileID: 0}
   effectOnBreak: {fileID: 0}
   destructibilityParent: {fileID: 8889384663306031710}
-  maxHealth: 1
+  maxHealth: 200
+  reparable: 1
   repairCost: 1
+  spawnsDebris: 1
   mass: 1
   collisionFalsePositivePreventionTimeout: 0.25
 --- !u!114 &8831864996751808317

--- a/Assets/Prefabs/Enemies/test cannonball.prefab
+++ b/Assets/Prefabs/Enemies/test cannonball.prefab
@@ -119,7 +119,7 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2825221901041224626}
   serializedVersion: 4
-  m_Mass: 1
+  m_Mass: 5
   m_Drag: 0
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Props/Destructible Mesh Piece.cs
+++ b/Assets/Scripts/Props/Destructible Mesh Piece.cs
@@ -7,7 +7,7 @@ public class DestructibleMeshPiece : MonoBehaviour
     public event Action broken;
     public event Action repaired;
 
-    [SerializeField] public DestructibleMesh ownerDestructibleMesh = null;
+    [SerializeField] private DestructibleMesh _ownerDestructibleMesh = null;
     [SerializeField] public TemporaryGameObject effectOnHit = null;
     [SerializeField] public TemporaryGameObject effectOnBreak = null;
     /* If a piece has a destructibility parent, the piece will always break
@@ -17,14 +17,22 @@ public class DestructibleMeshPiece : MonoBehaviour
      * across multiple projectile collisions
      * before it will break off. */
     [SerializeField] public float maxHealth = 1.0f;
+    [SerializeField] public bool reparable = true;
     [SerializeField] public int repairCost = 1;
+    [SerializeField] public bool spawnsDebris = true;
     [SerializeField] public float mass = 1.0f;
     [SerializeField] public float collisionFalsePositivePreventionTimeout = 0.25f;
 
+    public DestructibleMesh ownerDestructibleMesh {get => _ownerDestructibleMesh;}
     public float health {get; private set;}
     public bool attached {get; private set;}
 
     private float collisionFalsePositivePreventionTimer = 0.0f;
+
+    void Awake()
+    {
+        ownerDestructibleMesh.RegisterPiece(this);
+    }
 
     void Start()
     {
@@ -101,8 +109,8 @@ public class DestructibleMeshPiece : MonoBehaviour
             broken?.Invoke();
             health = 0.0f;
             attached = false;
-            CreateRepairSite();
-            CreateDebris(impulse);
+            if (reparable) CreateRepairSite();
+            if (spawnsDebris) CreateDebris(impulse);
             if (effectOnBreak != null)
             {
                 Instantiate(
@@ -173,7 +181,7 @@ public class DestructibleMeshPiece : MonoBehaviour
         var temp = debris.gameObject.AddComponent<TemporaryGameObject>();
         temp.destroyAfterTimeout = true;
         temp.destroyAtKillPlane = true;
-        temp.destroyWhenNotVisible = false;
+        temp.destroyWhenNotVisible = true;
         var srcRend = GetComponent<MeshRenderer>();
         var dstRend = debris.GetComponent<MeshRenderer>();
         if (srcRend && dstRend)

--- a/Assets/Scripts/Props/Destructible Mesh.cs
+++ b/Assets/Scripts/Props/Destructible Mesh.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 public class DestructibleMesh : MonoBehaviour
 {
@@ -14,6 +15,27 @@ public class DestructibleMesh : MonoBehaviour
      * to get to the DestructibleMesh's pieces), specify that Rigidbody here.
      * TakeHit will then propagate impulses it receives to the Rigidbody. */
     [SerializeField] public Rigidbody syncedRigidbody = null;
+
+    private List<DestructibleMeshPiece> _pieces = new();
+    public ReadOnlyCollection<DestructibleMeshPiece> pieces
+    {
+        get => _pieces.AsReadOnly();
+    }
+
+    public void RegisterPiece(DestructibleMeshPiece piece)
+    {
+        if (piece.ownerDestructibleMesh != this)
+        {
+            throw new ExceptionAbout<DestructibleMesh>(
+                $"Tried to register destructible mesh piece {piece} " +
+                $"with non-owning destructible mesh {this}"
+            );
+        }
+        else if (!_pieces.Contains(piece))
+        {
+            _pieces.Add(piece);
+        }
+    }
 
     public void TakeHit(Vector3 source, Vector3 impulse)
     {
@@ -31,20 +53,62 @@ public class DestructibleMesh : MonoBehaviour
                     }
                     else
                     {
+                        float lerpWeight = disp.magnitude/radius;
                         piece.TakeDamage(Vector3.Slerp(
                             impulse.normalized,
                             disp.normalized,
-                            disp.magnitude/radius
-                        ).normalized*impulse.magnitude);
+                            lerpWeight
+                        ).normalized*Mathf.Lerp(
+                            impulse.magnitude, 0.0f,
+                            lerpWeight
+                        ));
                     }
                 }
             }
-            /*if (syncedRigidbody != null)
+            if (syncedRigidbody != null)
             {
                 syncedRigidbody.AddForceAtPosition(
                     -impulse, source, ForceMode.Impulse
                 );
-            }*/
+            }
+        }
+    }
+
+    public float GetHealth()
+    {
+        float health = 0.0f;
+        foreach (var piece in _pieces)
+        {
+            health += piece.health;
+        }
+        return health;
+    }
+
+    public float GetMaxHealth()
+    {
+        float maxHealth = 0.0f;
+        foreach (var piece in _pieces)
+        {
+            maxHealth += piece.maxHealth;
+        }
+        return maxHealth;
+    }
+
+    public void FullRepair()
+    {
+        foreach (var piece in _pieces)
+        {
+            piece.Repair();
+        }
+    }
+
+    public void Explode(float impulsePerUnitDistance = 1.0f)
+    {
+        foreach (var piece in _pieces)
+        {
+            piece.BreakOff(impulsePerUnitDistance*(
+                piece.transform.position - transform.position
+            ));
         }
     }
 }


### PR DESCRIPTION
Summary of changes:
* Cannonball mass is now 5 instead of 1.
* Ship health per piece is now 200 instead of 30.
* `DestructibleMeshPiece` fields `reparable` and `spawnsDebris` control whether the piece spawns a repair site and/or a debris object when destroyed, respectively.
* `DestructibleMeshPiece.ownerDestructibleMesh` is now read-only.
* `DestructibleMeshPiece` debris objects now despawn when not visible.
* `DestructibleMesh` now knows what pieces it has (`DestructibleMesh.pieces`) and can do several things with that information (`DestructibleMeshPiece.GetHealth`, `DestructibleMeshPiece.GetMaxHealth`, `DestructibleMeshPiece.FullRepair`, `DestructibleMeshPiece.Explode`).
* Uncommented code that propels `DestructibleMesh.syncedRigidbody` away from collisions as if the synced body's own convex hull had been hit.
* The magnitude, and not only the direction, of the impulse received by each piece affected by a collision, is now attenuated by the piece's distance from the collision. This was the intended behavior to begin with, and the prior behavior (attenuating only direction) was in error.